### PR TITLE
Cargo fix and readme updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Cargo.lock
 *.pdb
 
 **/.DS_Store
+
+# Python virtual environment 
+python/venv/

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ This project is licensed under the terms of the MIT license.
 
 The OpenAI Whisper models that have been converted to work in burn are available in the whisper-burn space on Hugging Face. You can find them at [https://huggingface.co/Gadersd/whisper-burn](https://huggingface.co/Gadersd/whisper-burn).
 
-If you have a custom fine-tuned model you can easily convert it to burn's format. Here is an example of converting OpenAI's tiny en model. The tinygrad dependency of the dump.py script should be installed from source not with pip.
+If you have a custom fine-tuned model you can easily convert it to burn's format. Here is an example of converting OpenAI's tiny en model:
 
 ```
-# Download the tiny_en tokenizer
-wget https://huggingface.co/Gadersd/whisper-burn/resolve/main/tiny_en/tokenizer.json
-
 cd python
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
 wget https://openaipublic.azureedge.net/main/whisper/models/d3dd57d32accea0b295c96e26691aa14d8822fac7d9d27d5dc00b4ca2826dd03/tiny.en.pt
 python3 dump.py tiny.en.pt tiny_en
 mv tiny_en ../

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,5 @@
 numpy
 typing
 torch
+tinygrad
 git+https://github.com/bayartsogt-ya/whisper-multiple-hf-datasets@main

--- a/src/beam.rs
+++ b/src/beam.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+
 
 #[derive(Clone)]
 pub struct BeamNode<T: Clone> {

--- a/src/bin/convert/main.rs
+++ b/src/bin/convert/main.rs
@@ -2,9 +2,7 @@ use whisper::model::{load::*, *};
 
 use burn::{
     module::Module,
-    tensor::{
-        backend::{Backend},
-    },
+    tensor::backend::Backend,
 };
 
 use burn_tch::{TchBackend, TchDevice};

--- a/src/bin/convert/main.rs
+++ b/src/bin/convert/main.rs
@@ -3,9 +3,7 @@ use whisper::model::{load::*, *};
 use burn::{
     module::Module,
     tensor::{
-        self,
-        backend::{self, Backend},
-        Int, Tensor,
+        backend::{Backend},
     },
 };
 
@@ -30,7 +28,7 @@ fn main() {
     };
 
     type Backend = TchBackend<f32>;
-    let device = TchDevice::Cpu;
+    let _device = TchDevice::Cpu;
 
     let (whisper, whisper_config): (Whisper<Backend>, WhisperConfig) =
         match load_whisper(&model_name) {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,5 +1,5 @@
 use burn::tensor::{
-    activation::relu, backend::Backend, BasicOps, Bool, Element, Float, Int, Numeric, Tensor,
+    activation::relu, backend::Backend, BasicOps, Element, Numeric, Tensor,
     TensorKind,
 };
 

--- a/src/model/load.rs
+++ b/src/model/load.rs
@@ -5,7 +5,7 @@ use burn::{
         conv::{Conv1d, Conv1dConfig, Conv1dRecord},
         PaddingConfig1d,
     },
-    tensor::{activation::relu, backend::Backend, Bool, Int, Tensor},
+    tensor::{backend::Backend, Tensor},
 };
 
 use super::*;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,7 +7,7 @@ use burn::{
     module::{Module, Param},
     nn::{
         self,
-        conv::{Conv1d, Conv1dConfig, Conv1dRecord},
+        conv::{Conv1d, Conv1dConfig},
         PaddingConfig1d,
     },
     tensor::{activation::softmax, backend::Backend, module::embedding, Distribution, Int, Tensor},
@@ -129,7 +129,7 @@ pub struct TextDecoder<B: Backend> {
 
 impl<B: Backend> TextDecoder<B> {
     fn forward(&self, x: Tensor<B, 2, Int>, xa: Tensor<B, 3>) -> Tensor<B, 3> {
-        let [n_batch, seq_len] = x.dims();
+        let [_n_batch, seq_len] = x.dims();
 
         assert!(
             seq_len <= self.n_text_ctx,

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 use serde::ser::StdError;
 use std::result;
 
-use tokenizers::{AddedToken, Tokenizer};
+use tokenizers::{AddedToken};
 
 pub type Result<T> = result::Result<T, Box<(dyn StdError + Send + Sync + 'static)>>;
 
@@ -12,7 +12,7 @@ pub struct Gpt2Tokenizer {
 impl Gpt2Tokenizer {
     pub fn new() -> Result<Self> {
         //let mut tokenizer = tokenizers::Tokenizer::from_pretrained("gpt2", None)?;
-        let mut tokenizer = tokenizers::Tokenizer::from_file("tokenizer.json")?;
+        let tokenizer = tokenizers::Tokenizer::from_file("tokenizer.json")?;
         //tokenizer.add_special_tokens(&construct_special_tokens());
 
         Ok(Self { tokenizer })


### PR DESCRIPTION
Hi, made some minor cleanups:
- tinygrad from pip worked fine for me (on linux) so I added it to the requirements file - is this an issue on other platforms?
- Updated the readme on the commands used to set up the virtual env
   - I placed it in the python dir, feel free to move or remove 
   - Removed the download of the tokenizer in the convert step as it doesn't seem to be necessary and is included in step 2 Download 
- Applied cargo fix. There are a lot of unused functions left untouched  